### PR TITLE
Adding parameter validation to prevent runtime error

### DIFF
--- a/Slivers/Rift/Rise_of_the_Phoenix/Arakhurn.lua
+++ b/Slivers/Rift/Rise_of_the_Phoenix/Arakhurn.lua
@@ -54,6 +54,7 @@ HA.Arakhurn = {
 		CastBar = KBM.Defaults.Castbar(),
 		TimersRef = {
 			Enabled = true,
+			LavaFirst = KBM.Defaults.TimerObj.Create("red"),
 			NovaFirst = KBM.Defaults.TimerObj.Create("red"),
 			Nova = KBM.Defaults.TimerObj.Create("red"),
 			NovaPThree = KBM.Defaults.TimerObj.Create("red"),


### PR DESCRIPTION
in RoTP, a null-ref runtime error was occurring for High Priest Arakhurn