### PR TITLE
Add alias for `playerIDDebuff` to `playerIDBuff`

### DIFF
--- a/KingMolinator.lua
+++ b/KingMolinator.lua
@@ -2390,7 +2390,7 @@ function KBM:BuffAdd(handle, Units)
 								local TriggerObj = KBM.Trigger.PlayerIDBuff[KBM.CurrentMod.ID][bDetails.type]
 								if LibSUnit.Raid.UID[unitID] ~= nil or unitID == LibSUnit.Player.UnitID then
 									if KBM.Debug then
-										print("Debuff Trigger matched: "..bDetails.name)
+										print("Debuff Trigger matched by id: "..bDetails.name)
 										if LibSUnit.Raid.Grouped then
 											print("LibSUnit Match: "..tostring(LibSUnit.Raid.UID[unitID]))
 										end

--- a/Modules/Triggers.lua
+++ b/Modules/Triggers.lua
@@ -578,7 +578,7 @@ function KBM.Trigger:Init()
 					-- self.PlayerDebuff[Unit.Mod.ID] = {}
 				-- end
 				-- self.PlayerDebuff[Unit.Mod.ID][Trigger] = TriggerObj
-			elseif Type == "playerIDBuff" then
+			elseif Type == "playerIDBuff" or Type == "playerIDDebuff" then
 				if not self.PlayerIDBuff[Unit.Mod.ID] then
 					self.PlayerIDBuff[Unit.Mod.ID] = {}
 				end


### PR DESCRIPTION
To match a buff by its id in place of it's name you have to do
something like this:

```
- self.Ereandorn.Triggers.Combustion = KBM.Trigger:Create(self.Lang.Ability.Combustion[KBM.Lang], "playerDebuff", self.Ereandorn)
+ self.Ereandorn.Triggers.Combustion = KBM.Trigger:Create("B485934936A35E03D", "playerIDDebuff", self.Ereandorn)

```
replace the first line per the second line, everything else is the same