### PR TITLE
Add `buffID` and `buffIDRemove` on triggers

### DIFF
--- a/KingMolinator.lua
+++ b/KingMolinator.lua
@@ -2353,6 +2353,36 @@ function KBM:BuffAdd(handle, Units)
 									local TriggerObj = KBM.Trigger.Buff[KBM.CurrentMod.ID][bDetails.name][uDetails.Name]
 									if TriggerObj then
 										if TriggerObj.Unit.UnitID == unitID then
+											if KBM.Debug then
+												print("Bossbuff Trigger matched: "..bDetails.name)
+												dump(bDetails)
+											end
+											if TriggerObj.MinStack then
+												if bDetails.stack then
+													if bDetails.stack < TriggerObj.MinStack then
+														return
+													end
+												else 
+													return
+												end
+											end
+											KBM.Trigger.Queue:Add(TriggerObj, unitID, unitID, bDetails.remaining)
+										end
+									end
+								end
+							end
+						end
+						if KBM.Trigger.BuffID[KBM.CurrentMod.ID] then
+							if KBM.Trigger.BuffID[KBM.CurrentMod.ID][bDetails.type] then
+								local uDetails = LibSUnit.Lookup.UID[unitID]
+								if uDetails then
+									local TriggerObj = KBM.Trigger.BuffID[KBM.CurrentMod.ID][bDetails.type][uDetails.Name]
+									if TriggerObj then
+										if TriggerObj.Unit.UnitID == unitID then
+											if KBM.Debug then
+												print("Bossbuff Trigger matched by id: "..bDetails.name)
+												dump(bDetails)
+											end
 											if TriggerObj.MinStack then
 												if bDetails.stack then
 													if bDetails.stack < TriggerObj.MinStack then
@@ -2501,6 +2531,27 @@ function KBM:BuffRemove(handle, Units)
 									local TriggerObj = KBM.Trigger.BuffRemove[KBM.CurrentMod.ID][bDetails.name][uDetails.Name]
 									if TriggerObj then
 										if TriggerObj.Unit.UnitID == unitID then
+											if KBM.Debug then
+												print("BossbuffRemove Trigger matched: "..bDetails.name)
+												dump(bDetails)
+											end
+											KBM.Trigger.Queue:Add(TriggerObj, nil, unitID, nil)
+										end
+									end
+								end
+							end
+						end
+						if KBM.Trigger.BuffIDRemove[KBM.CurrentMod.ID] then
+							if KBM.Trigger.BuffIDRemove[KBM.CurrentMod.ID][bDetails.type] then
+								local uDetails = LibSUnit.Lookup.UID[unitID]
+								if uDetails then
+									local TriggerObj = KBM.Trigger.BuffIDRemove[KBM.CurrentMod.ID][bDetails.type][uDetails.Name]
+									if TriggerObj then
+										if TriggerObj.Unit.UnitID == unitID then
+											if KBM.Debug then
+												print("BossbuffRemove Trigger matched by id: "..bDetails.name)
+												dump(bDetails)
+											end
 											KBM.Trigger.Queue:Add(TriggerObj, nil, unitID, nil)
 										end
 									end

--- a/Modules/Triggers.lua
+++ b/Modules/Triggers.lua
@@ -21,10 +21,12 @@ function KBM.Trigger:Init()
 	self.Start = {}
 	self.Death = {}
 	self.Buff = {}
+	self.BuffID = {}
 	self.PlayerBuff = {}
 	self.PlayerDebuff = {}
 	self.PlayerIDBuff = {}
 	self.BuffRemove = {}
+	self.BuffIDRemove = {}
 	self.PlayerBuffRemove = {}
 	self.PlayerIDBuffRemove = {}
 	self.Time = {}
@@ -555,6 +557,14 @@ function KBM.Trigger:Init()
 					self.Buff[Unit.Mod.ID][Trigger] = {}
 				end
 				self.Buff[Unit.Mod.ID][Trigger][Unit.Name] = TriggerObj
+			elseif Type == "buffID" then
+				if not self.BuffID[Unit.Mod.ID] then
+					self.BuffID[Unit.Mod.ID] = {}
+				end
+				if not self.BuffID[Unit.Mod.ID][Trigger] then
+					self.BuffID[Unit.Mod.ID][Trigger] = {}
+				end
+				self.BuffID[Unit.Mod.ID][Trigger][Unit.Name] = TriggerObj
 			elseif Type == "buffRemove" then
 				if not self.BuffRemove[Unit.Mod.ID] then
 					self.BuffRemove[Unit.Mod.ID] = {}
@@ -563,6 +573,14 @@ function KBM.Trigger:Init()
 					self.BuffRemove[Unit.Mod.ID][Trigger] = {}
 				end
 				self.BuffRemove[Unit.Mod.ID][Trigger][Unit.Name] = TriggerObj
+			elseif Type == "buffIDRemove" then
+				if not self.BuffIDRemove[Unit.Mod.ID] then
+					self.BuffIDRemove[Unit.Mod.ID] = {}
+				end
+				if not self.BuffIDRemove[Unit.Mod.ID][Trigger] then
+					self.BuffIDRemove[Unit.Mod.ID][Trigger] = {}
+				end
+				self.BuffIDRemove[Unit.Mod.ID][Trigger][Unit.Name] = TriggerObj
 			elseif Type == "playerBuff" or Type == "playerDebuff" then
 				if not self.PlayerBuff[Unit.Mod.ID] then
 					self.PlayerBuff[Unit.Mod.ID] = {}


### PR DESCRIPTION
This allow to match a buff on a mob by its id rather than its name.

Example:
```
- self.Fetlorn.Triggers.Shield = KBM.Trigger:Create(self.Lang.Buff.Shield[KBM.Lang], "buff", self.Fetlorn)
+ self.Fetlorn.Triggers.Shield = KBM.Trigger:Create("B7B9EC401644B7E1D", "buffID", self.Fetlorn)
```